### PR TITLE
add Dockerfile and script docker_run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:bookworm
+
+RUN apt-get update && apt-get install -y \
+    gcc-arm-linux-gnueabihf \
+    python3 \
+    python3-pip \
+    git \
+    make && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+CONTAINER_NAME="kaeru"
+DOCKERFILE="Dockerfile"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! docker image inspect "$CONTAINER_NAME" &> /dev/null; then
+    echo "Container not found, building..."
+    docker build -t "$CONTAINER_NAME" -f "$SCRIPT_DIR/$DOCKERFILE" "$SCRIPT_DIR"
+fi
+
+docker run -it --rm \
+    -v "$SCRIPT_DIR":/kaeru \
+    -w /kaeru \
+    "$CONTAINER_NAME" \
+    bash


### PR DESCRIPTION
Now we can quickly and easily start using kaeru on any toaster =)

There is one nuance - the lk files need to be copied to the directory with kaeru, but this is even a plus, everything is isolated and therefore awesome.