### PR TITLE
kaeru: Add libsej for interacting with SEJ/HACC

### DIFF
--- a/include/board_ops.h
+++ b/include/board_ops.h
@@ -20,5 +20,9 @@
 #include <lib/framebuffer.h>
 #endif
 
+#ifdef CONFIG_LIBSEJ_SUPPORT
+#include <lib/sej.h>
+#endif
+
 void board_early_init(void);
 void board_late_init(void);

--- a/include/lib/sej.h
+++ b/include/lib/sej.h
@@ -1,0 +1,207 @@
+// Copyright 2024 (c) B.Kerler
+// Copyright 2025 (c) Shomy
+// Use of this source code is governed by a GPLv3 license, see LICENSE.txt.
+
+#ifndef SEJ_H
+#define SEJ_H
+#include <stdint.h>
+#include <stdbool.h>
+
+extern volatile uint32_t hacc_base;
+
+static inline volatile uint32_t* SEJ_REG(uint32_t offset) {
+    return (volatile uint32_t*)((uintptr_t)hacc_base + offset);
+}
+
+#define SEJ_CG                      (0x1 << 10)
+
+#define HACC_AES_TEST_SRC            (0x02000000)
+#define HACC_AES_TEST_TMP            (0x02100000)
+#define HACC_AES_TEST_DST            (0x02200000)
+
+#define HACC_CFG_0                    (0x5a5a3257)	/* CHECKME */
+#define HACC_CFG_1                    (0x66975412)	/* CHECKME */
+#define HACC_CFG_2                    (0x66975412)	/* CHECKME */
+#define HACC_CFG_3                    (0x5a5a3257)	/* CHECKME */
+
+#define SEJ_CON                     SEJ_REG(0x0000)
+#define SEJ_ACON                    SEJ_REG(0x0004)
+#define SEJ_ACON2                   SEJ_REG(0x0008)
+#define SEJ_ACONK                   SEJ_REG(0x000C)
+#define SEJ_ASRC0                   SEJ_REG(0x0010)
+#define SEJ_ASRC1                   SEJ_REG(0x0014)
+#define SEJ_ASRC2                   SEJ_REG(0x0018)
+#define SEJ_ASRC3                   SEJ_REG(0x001C)
+#define SEJ_AKEY0                   SEJ_REG(0x0020)
+#define SEJ_AKEY1                   SEJ_REG(0x0024)
+#define SEJ_AKEY2                   SEJ_REG(0x0028)
+#define SEJ_AKEY3                   SEJ_REG(0x002C)
+#define SEJ_AKEY4                   SEJ_REG(0x0030)
+#define SEJ_AKEY5                   SEJ_REG(0x0034)
+#define SEJ_AKEY6                   SEJ_REG(0x0038)
+#define SEJ_AKEY7                   SEJ_REG(0x003C)
+#define SEJ_ACFG0                   SEJ_REG(0x0040)
+#define SEJ_ACFG1                   SEJ_REG(0x0044)
+#define SEJ_ACFG2                   SEJ_REG(0x0048)
+#define SEJ_ACFG3                   SEJ_REG(0x004c)
+#define SEJ_AOUT0                   SEJ_REG(0x0050)
+#define SEJ_AOUT1                   SEJ_REG(0x0054)
+#define SEJ_AOUT2                   SEJ_REG(0x0058)
+#define SEJ_AOUT3                   SEJ_REG(0x005C)
+#define SEJ_SW_OTP0                 SEJ_REG(0x0060)
+#define SEJ_SW_OTP1                 SEJ_REG(0x0064)
+#define SEJ_SW_OTP2                 SEJ_REG(0x0068)
+#define SEJ_SW_OTP3                 SEJ_REG(0x006c)
+#define SEJ_SW_OTP4                 SEJ_REG(0x0070)
+#define SEJ_SW_OTP5                 SEJ_REG(0x0074)
+#define SEJ_SW_OTP6                 SEJ_REG(0x0078)
+#define SEJ_SW_OTP7                 SEJ_REG(0x007c)
+#define SEJ_SECINIT0                SEJ_REG(0x0080)
+#define SEJ_SECINIT1                SEJ_REG(0x0084)
+#define SEJ_SECINIT2                SEJ_REG(0x0088)
+#define SEJ_MKJ                     SEJ_REG(0x00a0)
+#define SEJ_UNK                     SEJ_REG(0x00bc)
+
+/* AES */
+#define SEJ_AES_DEC                 0x00000000
+#define SEJ_AES_ENC                 0x00000001
+#define SEJ_AES_MODE_MASK           0x00000002
+#define SEJ_AES_ECB                 0x00000000
+#define SEJ_AES_CBC                 0x00000002
+#define SEJ_AES_TYPE_MASK           0x00000030
+#define SEJ_AES_128                 0x00000000
+#define SEJ_AES_192                 0x00000010
+#define SEJ_AES_256                 0x00000020
+#define SEJ_AES_CHG_BO_MASK         0x00001000
+#define SEJ_AES_CHG_BO_OFF          0x00000000
+#define SEJ_AES_CHG_BO_ON           0x00001000
+#define SEJ_AES_START               0x00000001
+#define SEJ_AES_CLR                 0x00000002
+#define SEJ_AES_RDY                 0x00008000
+
+/* AES key relevant */
+#define SEJ_AES_BK2C                0x00000010
+#define SEJ_AES_R2K                 0x00000100
+
+/* SECINIT magic */
+#define SEJ_SECINIT0_MAGIC          0xAE0ACBEA
+#define SEJ_SECINIT1_MAGIC          0xCD957018
+#define SEJ_SECINIT2_MAGIC          0x46293911
+
+
+/******************************************************************************
+ * CONSTANT DEFINITIONS
+ ******************************************************************************/
+#define SEJ_AES_MAX_KEY_SZ          (32)
+#define AES_CFG_SZ                   (16)
+#define AES_BLK_SZ                  (16)
+#define SEJ_HW_KEY_SZ               (16)
+#define _CRYPTO_SEED_LEN            (16)
+
+/******************************************************************************
+ * TYPE DEFINITIONS
+ ******************************************************************************/
+typedef enum {
+	AES_ECB_MODE,
+	AES_CBC_MODE
+} AES_MODE;
+
+typedef enum {
+	AES_DEC,
+	AES_ENC
+} AES_OPS;
+
+typedef enum {
+	AES_KEY_128 = 16,
+	AES_KEY_192 = 24,
+	AES_KEY_256 = 32
+} AES_KEY_SZ;
+
+typedef enum {
+	AES_SW_KEY,
+	AES_HW_KEY,
+	AES_HW_WRAP_KEY,
+	AES_RID_KEY,
+	AES_CUSTOM_KEY
+} AES_KEY_ID;
+
+typedef struct {
+	unsigned char config[AES_CFG_SZ];
+} AES_CFG;
+
+typedef struct {
+	unsigned int size;
+	unsigned char seed[SEJ_AES_MAX_KEY_SZ];
+} AES_KEY_SEED;
+
+enum cryptmode_t {
+    SW_ENCRYPTED = 0,
+    HW_ENCRYPTED = 1,
+    HW_ENCRYPTED_5G = 2,
+    UNLOCK = 3
+};
+
+struct SymKey {
+    uint32_t* key;
+    uint8_t key_len;
+    uint8_t mode;
+    uint32_t* iv;
+    uint8_t iv_len;
+};
+
+typedef struct {
+    uint8_t vector[16];
+} AES_IV;
+
+typedef struct {
+    AES_IV iv;
+    AES_IV custom_iv;
+    uint32_t blk_sz;
+    uint8_t sw_key[SEJ_AES_MAX_KEY_SZ];
+    uint8_t hw_key[SEJ_AES_MAX_KEY_SZ];
+    uint8_t rid_key[SEJ_AES_MAX_KEY_SZ];
+    uint8_t custom_key[SEJ_AES_MAX_KEY_SZ];
+    uint8_t use_custom_iv;
+} sej_ctx_t;
+
+#define READ_REGISTER_UINT32(reg) \
+	(*(volatile unsigned int * const)(reg))
+
+#define WRITE_REGISTER_UINT32(reg, val) \
+	((*(volatile unsigned int * const)(reg)) = (val))
+
+#define INREG32(x)          READ_REGISTER_UINT32((unsigned int *)((void *)(x)))
+#define OUTREG32(x, y)      WRITE_REGISTER_UINT32((unsigned int *)((void *)(x)), (unsigned int)(y))
+#define SETREG32(x, y)      OUTREG32(x, INREG32(x)|(y))
+#define CLRREG32(x, y)      OUTREG32(x, INREG32(x)&~(y))
+#define MASKREG32(x, y, z)  OUTREG32(x, (INREG32(x)&~(y))|(z))
+
+extern sej_ctx_t g_sej_ctx;
+extern const unsigned int g_HACC_CFG_1[8];
+extern const unsigned int g_HACC_CFG_2[8];
+extern const unsigned int g_HACC_CFG_3[8];
+extern const uint32_t G_CFG_RANDOM_PATTERN[12];
+extern const uint8_t DEFAULT_IV[16];
+extern const uint8_t DEFAULT_KEY[32];
+
+
+void SEJ_V3_init(bool encrypt, const uint32_t* iv, bool legacy);
+void SEJ_V3_Run(volatile uint32_t* p_src, uint32_t length, volatile uint32_t* p_dst);
+void SEJ_V3_Terminate(void);
+
+int32_t sej_set_otp(uint32_t* otp);
+uint32_t sej_set_iv(AES_IV* iv);
+uint32_t sej_set_custom_key(uint8_t* key, uint32_t size);
+uint32_t sej_set_custom_iv(AES_IV* iv, uint32_t size);
+uint32_t sej_set_custom_key(uint8_t* key, uint32_t size);
+
+int sej_set_key(AES_KEY_ID id,AES_KEY_SZ key);
+int sej_do_aes(AES_OPS ops, uint8_t* src, uint8_t* dst, uint32_t size);
+uint32_t sej_set_mode(AES_MODE mode);
+int sp_sej_enc(uint8_t* buf, uint8_t* out, uint32_t size, bool anti_clone, bool legacy);
+int sp_sej_dec(uint8_t* buf, uint8_t* out, uint32_t size, bool anti_clone, bool legacy);
+void init_sej_ctx(void);
+void set_sej_base(uint32_t base_addr);
+uint32_t get_sej_base(void);
+
+#endif // SEJ_H

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -7,7 +7,7 @@ menu "Framebuffer Support"
 		help
 		  Enable the framebuffer library for drawing graphics and text.
 		  This adds support for basic shapes, text rendering, and UI elements.
-		  
+
 		  Say Y unless you want to minimize binary size and don't need graphics.
 
 	if FRAMEBUFFER_SUPPORT
@@ -50,7 +50,7 @@ menu "Framebuffer Support"
 			help
 			  Number of bits per pixel. Common values:
 			  16 - RGB565 format
-			  24 - RGB888 format  
+			  24 - RGB888 format
 			  32 - ARGB8888 format (recommended)
 
 		config FRAMEBUFFER_BYTES_PER_PIXEL
@@ -103,15 +103,15 @@ menu "Thread Support"
         default n
         help
           Say Y if you want to create your own threads
-    
+
     config THREAD_CREATE_ADDRESS
         hex "Thread create address"
         depends on THREAD_SUPPORT
         help
           Address for thread creation function
-    
+
     config THREAD_RESUME_ADDRESS
-        hex "Thread resume address" 
+        hex "Thread resume address"
         depends on THREAD_SUPPORT
         help
           Address for thread resume function
@@ -210,4 +210,13 @@ menu "Logging Options"
         depends on LK_LOG_STORE
         help
           Address of the lk_log_store() function in the bootloader
+endmenu
+
+menu "Third party libraries"
+    config LIBSEJ_SUPPORT
+        bool "Enable libsej support"
+        default n
+        help
+          Say Y to enable libsej support, allowing to interact with
+          the device crypto engine.
 endmenu

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -3,3 +3,4 @@ obj-y += debug/debug.o
 obj-$(CONFIG_FRAMEBUFFER_SUPPORT) += framebuffer/
 obj-y += common.o bootmode.o fastboot.o
 obj-$(CONFIG_THREAD_SUPPORT) += thread.o
+obj-$(CONFIG_LIBSEJ_SUPPORT) += libsej/

--- a/lib/libsej/Makefile
+++ b/lib/libsej/Makefile
@@ -1,0 +1,1 @@
+obj-$(CONFIG_LIBSEJ_SUPPORT) += sej.o

--- a/lib/libsej/sej.c
+++ b/lib/libsej/sej.c
@@ -1,0 +1,379 @@
+// Copyright 2024 (c) B.Kerler
+// Copyright 2025 (c) Shomy
+// Use of this source code is governed by a GPLv3 license, see LICENSE.txt.
+
+#include <lib/sej.h>
+#include <stdint.h>
+
+#define ERR_SEC_CYPHER_KEY_INVALID 0xC0020032
+#define ERR_SEC_CYPHER_DATA_UNALIGNED 0xC0020033
+
+uint32_t g_UnqKey_IV[8] = {0x6786CFBD, 0x44B7F1E0, 0x1544B07B, 0x53A28EB3, 0xD7AB8AA2, 0xB9E30E7E, 0x172156E0, 0x3064C973};
+
+sej_ctx_t g_sej_ctx;
+
+const uint32_t G_CFG_RANDOM_PATTERN[12] = {
+    0x2D44BB70, 0xA744D227, 0xD0A9864B, 0x83FFC244,
+    0x7EC8266B, 0x43E80FB2, 0x01A6348A, 0x2067F9A0,
+    0x54536405, 0xD546A6B1, 0x1CC3EC3A, 0xDE377A83
+};
+
+const unsigned int g_HACC_CFG_1[8] = {
+	0x9ED40400, 0x00E884A1, 0xE3F083BD, 0x2F4E6D8A,
+	0xFF838E5C, 0xE940A0E3, 0x8D4DECC6, 0x45FC0989
+};
+
+const unsigned int g_HACC_CFG_2[8] = {
+	0xAA542CDA, 0x55522114, 0xE3F083BD, 0x55522114,
+	0xAA542CDA, 0xAA542CDA, 0x55522114, 0xAA542CDA
+};
+
+const unsigned int g_HACC_CFG_3[8] = {
+	0x2684B690, 0xEB67A8BE, 0xA113144C, 0x177B1215,
+	0x168BEE66, 0x1284B684, 0xDF3BCE3A, 0x217F6FA2
+};
+
+const uint8_t DEFAULT_IV[16] = {
+    0x57, 0x32, 0x5A, 0x5A,
+    0x12, 0x54, 0x97, 0x66,
+    0x12, 0x54, 0x97, 0x66,
+    0x57, 0x32, 0x5A, 0x5A
+};
+
+const uint8_t DEFAULT_KEY[32] = {
+    0x25, 0xA1, 0x76, 0x3A, 0x21, 0xBC, 0x85, 0x4C,
+    0xD5, 0x69, 0xDC, 0x23, 0xB4, 0x78, 0x2B, 0x63,
+    0x25, 0xA1, 0x76, 0x3A, 0x21, 0xBC, 0x85, 0x4C,
+    0xD5, 0x69, 0xDC, 0x23, 0xB4, 0x78, 0x2B, 0x63
+};
+
+
+volatile uint32_t hacc_base=0x1000a000;
+
+int32_t toSigned32(uint32_t n){
+    n = n & 0xffffffff;
+    return n | (-(n & 0x80000000));
+}
+
+static uint32_t get_world_clock_value(void){
+    return INREG32(0x10017008);
+}
+
+int32_t check_timeout(const uint32_t clockvalue, int32_t timeout){
+    uint32_t tmp = -clockvalue;
+    const uint32_t curtime = get_world_clock_value();
+    if (curtime < clockvalue){
+        tmp = ~clockvalue;
+    }
+    return tmp + get_world_clock_value() >= ((uint32_t)timeout)*1000*13;
+}
+
+#define NULL 0
+
+void SEJ_V3_init(bool encrypt, const uint32_t* iv, bool legacy) {
+    uint32_t acon_settings =
+        SEJ_AES_CHG_BO_OFF |
+        SEJ_AES_128 |
+        ((iv != 0) ? SEJ_AES_CBC : 0) |
+        (encrypt ? SEJ_AES_ENC : SEJ_AES_DEC);
+
+    for (int i = 0; i < 8; i++) {
+        OUTREG32(SEJ_AKEY0 + (i * 4), 0);
+    }
+
+    OUTREG32(SEJ_ACON,  SEJ_AES_CHG_BO_OFF | SEJ_AES_CBC | SEJ_AES_128 | SEJ_AES_DEC);
+    OUTREG32(SEJ_ACONK, SEJ_AES_BK2C | SEJ_AES_R2K);
+    OUTREG32(SEJ_ACON2, SEJ_AES_CLR);
+
+    if (iv != 0) {
+        OUTREG32(SEJ_ACFG0, iv[0]);
+        OUTREG32(SEJ_ACFG1, iv[1]);
+        OUTREG32(SEJ_ACFG2, iv[2]);
+        OUTREG32(SEJ_ACFG3, iv[3]);
+    }
+
+    if (!legacy) {
+        /* Non legacy SEJ impl */
+        uint32_t val = INREG32(SEJ_UNK) | 2;
+        OUTREG32(SEJ_UNK, val);
+
+        val = INREG32(SEJ_ACON2) | 0x40000000;
+        OUTREG32(SEJ_ACON2, val);
+
+        while(!(INREG32(SEJ_ACON2) > 0x80000000));
+
+        val = INREG32(SEJ_UNK) & 0xFFFFFFFE;
+        OUTREG32(SEJ_UNK, val);
+        OUTREG32(SEJ_ACONK, SEJ_AES_BK2C);
+        OUTREG32(SEJ_ACON, acon_settings);
+    } else {
+        /* Legacy impl of SEJ. Used mainly in SECCFG V3 devices */
+        // This breaks everything, so commenting out for now
+        // OUTREG32(SEJ_UNK, 1);
+
+        // Derives a patterns based from HUID
+        for (int i = 0; i < 3; i++) {
+            const uint32_t* pattern_block = &G_CFG_RANDOM_PATTERN[i * 4];
+
+            OUTREG32(SEJ_ASRC0, pattern_block[0]);
+            OUTREG32(SEJ_ASRC1, pattern_block[1]);
+            OUTREG32(SEJ_ASRC2, pattern_block[2]);
+            OUTREG32(SEJ_ASRC3, pattern_block[3]);
+
+            OUTREG32(SEJ_ACON2, SEJ_AES_START);
+            while(!(INREG32(SEJ_ACON2) & SEJ_AES_RDY));
+        }
+
+        OUTREG32(SEJ_ACON2, SEJ_AES_CLR);
+
+        if (iv != 0) {
+            OUTREG32(SEJ_ACFG0, iv[0]);
+            OUTREG32(SEJ_ACFG1, iv[1]);
+            OUTREG32(SEJ_ACFG2, iv[2]);
+            OUTREG32(SEJ_ACFG3, iv[3]);
+        }
+
+        OUTREG32(SEJ_ACON, acon_settings);
+        OUTREG32(SEJ_ACONK, 0);
+    }
+}
+
+void SEJ_V3_Run(volatile uint32_t* p_src, uint32_t length, volatile uint32_t* p_dst) {
+    uint32_t processed_bytes = 0;
+
+    while (processed_bytes < length) {
+        OUTREG32(SEJ_ASRC0, p_src[0]);
+        OUTREG32(SEJ_ASRC1, p_src[1]);
+        OUTREG32(SEJ_ASRC2, p_src[2]);
+        OUTREG32(SEJ_ASRC3, p_src[3]);
+
+        OUTREG32(SEJ_ACON2, SEJ_AES_START);
+
+        while(!(INREG32(SEJ_ACON2) & SEJ_AES_RDY));
+
+        p_dst[0] = INREG32(SEJ_AOUT0);
+        p_dst[1] = INREG32(SEJ_AOUT1);
+        p_dst[2] = INREG32(SEJ_AOUT2);
+        p_dst[3] = INREG32(SEJ_AOUT3);
+
+        p_src += 4;
+        p_dst += 4;
+
+        processed_bytes += 16;
+    }
+}
+
+void SEJ_V3_Terminate(void) {
+    OUTREG32(SEJ_ACON2,SEJ_AES_CLR);
+    for (int32_t i = 0; i < 8; i++){
+        OUTREG32(SEJ_AKEY0 + (4 * i),0);
+    }
+}
+
+int32_t sej_set_otp(uint32_t* otp){
+    for (int32_t i = 0; i < 8; i++) {
+        OUTREG32(SEJ_SW_OTP0 + (4 * i),otp[i]);
+    }
+    return 0;
+}
+
+int sej_set_key(AES_KEY_ID id,AES_KEY_SZ key) {
+    if (0x10 < key - AES_KEY_128) {
+        return ERR_SEC_CYPHER_KEY_INVALID;
+    }
+
+    uint32_t val = 0;
+    uint8_t* p_key = g_sej_ctx.hw_key;
+    if (1) {
+        switch (id) {
+            case AES_HW_KEY:
+                p_key = g_sej_ctx.hw_key;
+                val = INREG32(SEJ_UNK) | 0x2;
+                OUTREG32(SEJ_UNK, val);
+                val = INREG32(SEJ_ACON2) | 0x40000000;
+                OUTREG32(SEJ_ACON2, val);
+
+                while ((INREG32(SEJ_ACON2) & 1) != 0);
+
+                g_sej_ctx.blk_sz = key;
+
+                val = INREG32(SEJ_ACONK) | 0x10;
+                OUTREG32(SEJ_ACONK, val);
+
+                for (int i=0; i < 8; i++)
+                    OUTREG32(SEJ_AKEY0 + (i * 4), 0);
+
+                val = INREG32(SEJ_UNK) & 0xFFFFFFFE;
+                OUTREG32(SEJ_UNK, val);
+                return 0;
+            case AES_HW_WRAP_KEY:
+                break;
+            case AES_RID_KEY:
+                p_key = g_sej_ctx.rid_key;
+                break;
+            case AES_CUSTOM_KEY:
+                p_key = g_sej_ctx.custom_key;
+                break;
+            default:
+                p_key = g_sej_ctx.sw_key;
+        }
+        for (int i=0; i < 8; i++) {
+            // Must be in BE
+            uint32_t word = (p_key[i*4] << 24) |
+                            (p_key[i*4+1] << 16) |
+                            (p_key[i*4+2] << 8) |
+                            (p_key[i*4+3]);
+            OUTREG32(SEJ_AKEY0 + (i * 4), word);
+        }
+        return 0;
+    }
+
+    return ERR_SEC_CYPHER_KEY_INVALID;
+}
+
+int sej_do_aes(AES_OPS ops, uint8_t* src, uint8_t* dst, uint32_t size)
+{
+    if ((((g_sej_ctx.blk_sz - 1) | 0xF) & size) != 0)
+        return ERR_SEC_CYPHER_DATA_UNALIGNED;
+
+    uint32_t val = 0;
+
+    AES_IV* iv = &g_sej_ctx.iv;;
+    if (g_sej_ctx.use_custom_iv) {
+        iv = &g_sej_ctx.custom_iv;
+    }
+
+    uint32_t* iv_words = (uint32_t*)iv->vector;
+    OUTREG32(SEJ_ACFG0, iv_words[0]);
+    OUTREG32(SEJ_ACFG1, iv_words[1]);
+    OUTREG32(SEJ_ACFG2, iv_words[2]);
+    OUTREG32(SEJ_ACFG3, iv_words[3]);
+
+    val = (INREG32(SEJ_ACON) & ~1) | (ops & 1);
+    OUTREG32(SEJ_ACON, val);
+
+    uint32_t* p_src = (uint32_t*)src;
+    uint32_t* p_dst = (uint32_t*)dst;
+    uint32_t processed_bytes = 0;
+
+    while (processed_bytes < size) {
+        OUTREG32(SEJ_ASRC0, p_src[0]);
+        OUTREG32(SEJ_ASRC1, p_src[1]);
+        OUTREG32(SEJ_ASRC2, p_src[2]);
+        OUTREG32(SEJ_ASRC3, p_src[3]);
+
+        SETREG32(SEJ_ACON2, SEJ_AES_START);
+
+        while (!(INREG32(SEJ_ACON2) & SEJ_AES_RDY));
+
+        p_dst[0] = INREG32(SEJ_AOUT0);
+        p_dst[1] = INREG32(SEJ_AOUT1);
+        p_dst[2] = INREG32(SEJ_AOUT2);
+        p_dst[3] = INREG32(SEJ_AOUT3);
+
+        p_src += 4;
+        p_dst += 4;
+        processed_bytes += 16;
+    }
+
+    return 0;
+}
+
+uint32_t sej_set_mode(AES_MODE mode) {
+    uint32_t val = 0;
+    val = INREG32(SEJ_ACON);
+    val &= ~(SEJ_AES_MODE_MASK);
+    val |= mode ? SEJ_AES_CBC : 0;
+    OUTREG32(SEJ_ACON, val);
+
+    if (mode == AES_ECB_MODE) {
+        for (int i = 0; i < 16; i++) {
+            g_sej_ctx.iv.vector[i] = 0;
+        }
+    }
+
+    return 0;
+}
+
+uint32_t sej_set_iv(AES_IV* iv) {
+    for (int i = 0; i < 16; i++) {
+        g_sej_ctx.iv.vector[i] = iv->vector[i];
+    }
+    return 0;
+}
+
+uint32_t sej_set_custom_iv(AES_IV* iv, uint32_t size) {
+    if (size > 0x16) {
+        return 1;
+    }
+
+    for (int i = 0; i < 16; i++) {
+        g_sej_ctx.custom_iv.vector[i] = iv->vector[i];
+    }
+    g_sej_ctx.use_custom_iv = 1;
+    return 0;
+}
+
+uint32_t sej_set_custom_key(uint8_t* key, uint32_t size) {
+    if (size != SEJ_AES_MAX_KEY_SZ) {
+        return ERR_SEC_CYPHER_KEY_INVALID;
+    }
+
+    for (int i = 0; i < SEJ_AES_MAX_KEY_SZ; i++) {
+        g_sej_ctx.custom_key[i] = key[i];
+    }
+
+    return 0;
+}
+
+int sp_sej_enc(uint8_t* buf, uint8_t* out, uint32_t size, bool anti_clone, bool legacy) {
+    int success = 0;
+    if (!anti_clone) {
+        sej_set_key(AES_SW_KEY, AES_KEY_256);
+        success = sej_do_aes(AES_ENC, buf, out, size);
+        return success;
+    }
+
+    SEJ_V3_init(AES_ENC, (const uint32_t*)g_HACC_CFG_1, legacy);
+    SEJ_V3_Run((volatile uint32_t*)buf, size, (volatile uint32_t*)out);
+    SEJ_V3_Terminate();
+    return success;
+}
+
+int sp_sej_dec(uint8_t* buf, uint8_t* out, uint32_t size, bool anti_clone, bool legacy) {
+    int success = 0;
+    if (!anti_clone) {
+        sej_set_key(AES_SW_KEY, AES_KEY_256);
+        success = sej_do_aes(AES_DEC, buf, out, size);
+        return success;
+    }
+
+    SEJ_V3_init(AES_DEC, (const uint32_t*)g_HACC_CFG_1, legacy);
+    SEJ_V3_Run((volatile uint32_t*)buf, size, (volatile uint32_t*)out);
+    SEJ_V3_Terminate();
+    return success;
+}
+
+void init_sej_ctx(void) {
+    AES_IV iv;
+
+    for (int i = 0; i < 32; i++) {
+        g_sej_ctx.sw_key[i] = DEFAULT_KEY[i];
+    }
+
+    for (int i = 0; i < 16; i++) {
+        iv.vector[i] = DEFAULT_IV[i];
+    }
+
+    sej_set_iv(&iv);
+    g_sej_ctx.blk_sz = 16;
+    g_sej_ctx.use_custom_iv = false;
+}
+
+void set_sej_base(uint32_t base_addr) {
+    hacc_base = base_addr;
+}
+
+uint32_t get_sej_base(void) {
+    return hacc_base;
+}

--- a/main/main.c
+++ b/main/main.c
@@ -9,11 +9,16 @@
 
 void kaeru(void) {
 #ifdef CONFIG_FRAMEBUFFER_SUPPORT
-    fb_init((uint32_t*)CONFIG_FRAMEBUFFER_ADDRESS, 
-            CONFIG_FRAMEBUFFER_WIDTH, 
-            CONFIG_FRAMEBUFFER_HEIGHT, 
+    fb_init((uint32_t*)CONFIG_FRAMEBUFFER_ADDRESS,
+            CONFIG_FRAMEBUFFER_WIDTH,
+            CONFIG_FRAMEBUFFER_HEIGHT,
             CONFIG_FRAMEBUFFER_BYTES_PER_PIXEL,
             CONFIG_FRAMEBUFFER_ALIGNMENT);
+#endif
+
+#ifdef CONFIG_LIBSEJ_SUPPORT
+    set_sej_base(CONFIG_SEJ_BASE);
+    init_sej_ctx();
 #endif
 
     board_late_init();

--- a/soc/Kconfig
+++ b/soc/Kconfig
@@ -25,7 +25,7 @@ config MEDIATEK_MT6757
 
 config MEDIATEK_MT6761
     bool "MediaTek MT6761 SoC"
-    
+
 config MEDIATEK_MT6762
     bool "MediaTek MT6762 SoC"
 
@@ -89,6 +89,29 @@ config SECURITY_AO_BASE
     default 0x1001A000 if MEDIATEK_MT8516
     default 0x1001A000 if MEDIATEK_MT6833
     default 0x1001A000 if MEDIATEK_MT6877
+
+config SEJ_BASE
+    hex "Security Engine for JTAG Protection / HACC base address"
+    default 0xF000A000 if MEDIATEK_MT6572
+    default 0x1000A000 if MEDIATEK_MT6580
+    default 0x10008000 if MEDIATEK_MT6737
+    default 0x1000A000 if MEDIATEK_MT6739
+    default 0x1000A000 if MEDIATEK_MT6750
+    default 0x1000A000 if MEDIATEK_MT6757
+    default 0x1000A000 if MEDIATEK_MT6761
+    default 0x1000A000 if MEDIATEK_MT6762
+    default 0x1000A000 if MEDIATEK_MT6765
+    default 0x1000A000 if MEDIATEK_MT6768
+    default 0x1000A000 if MEDIATEK_MT6771
+    default 0x1000A000 if MEDIATEK_MT6781
+    default 0x1000A000 if MEDIATEK_MT6785
+    default 0x1000A000 if MEDIATEK_MT6797
+    default 0x1000A000 if MEDIATEK_MT8127
+    default 0x1000A000 if MEDIATEK_MT8163
+    default 0x1000A000 if MEDIATEK_MT8168
+    default 0x1000A000 if MEDIATEK_MT8516
+    default 0x1000A000 if MEDIATEK_MT6833
+    default 0x1000A000 if MEDIATEK_MT6877
 
 config UART_BASE
     hex "UART base address"


### PR DESCRIPTION
This PR brings in libsej as a third party library from [mtk-payloads](https://github.com/shomykohai/mtk-payloads), to allow supporting hardware AES encryption and decryption.

Tested on `maya` for decrypting secro.

### Small suggestion

As for now, this is the first "third party module" kaeru brings in, but if we'll ever add more, it'd be nice for kaeru to have a really simple API for registering modules so that it won't pollute the main and lib directories, as well as not having to change the files for accomodate the compiler include paths.
