### PR TITLE
Fix shebangs for shell scripts on NixOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CONTAINER_NAME="kaeru"
 DOCKERFILE="Dockerfile"

--- a/format.sh
+++ b/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 print_usage() {
     echo "Usage: $0 [OPTIONS]"

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
Hello there!

Just chipping in a small PR. This commit fixes the bash scripts in the repo on some special distros (most notably NixOS, but some others do exist as well), where bash is not in the usual location where it is on most other systems (/bin/bash), using the `#!/usr/bin/env bash` shebang instead. This is probably a better practice anyway, but I totally get it for not using it if the former works on your machine already.

That's all, cheers & thanks for making this cool project! (it's been really fun to be able to run code inside my XA1's bootloader and also have an actual usable fastboot interface)