### PR TITLE
kaeru: Replace `Honor 8A` with `Honor 8S` as a twin of Huawei Y5 2019

### DIFF
--- a/board/Kconfig
+++ b/board/Kconfig
@@ -222,10 +222,10 @@ menu "Device Support"
           Say Y if you want to include support for Lenovo Tab M10HD (2nd Gen) WiFI
 
     config HUAWEI_KANSAS
-        bool "Support Huawei Y5 2019 / Honor 8A"
+        bool "Support Huawei Y5 2019 / Honor 8S"
         default n
         help
-          Say Y if you want to include support for Huawei Y5 2019 / Honor 8A
+          Say Y if you want to include support for Huawei Y5 2019 / Honor 8S
 
     config INFINIX_X6812
         bool "Support Infinix X6812"

--- a/board/huawei/board-kansas.c
+++ b/board/huawei/board-kansas.c
@@ -10,7 +10,7 @@
 #define VOLUME_DOWN 1
 
 void board_early_init(void) {
-    printf("Entering early init for Huawei Y5 2019 / Honor 8A\n");
+    printf("Entering early init for Huawei Y5 2019 / Honor 8S\n");
 
     // Likely unnecessary, but done as a precaution.
     //
@@ -37,7 +37,7 @@ void board_early_init(void) {
 }
 
 void board_late_init(void) {
-    printf("Entering late init for Huawei Y5 2019 / Honor 8A\n");
+    printf("Entering late init for Huawei Y5 2019 / Honor 8S\n");
 
     // Suppresses the bootloader unlock warning shown during boot on
     // unlocked devices. In addition to the visual warning, it also


### PR DESCRIPTION
Honor 8A (Play 8A, 8A Pro) and Huawei Y5 2019 are not the same devices. The first has MT6765 SOC, the second one has MT6761 SOC. But Honor 8S is essentially twin of Huawei Y5 2019. Full device comparison can be found [here](https://www.gsmarena.com/compare.php3?idPhone1=9675&idPhone2=9664&idPhone3=9662)